### PR TITLE
Added HadamardPower printing (#300)

### DIFF
--- a/symfit/core/printing.py
+++ b/symfit/core/printing.py
@@ -6,7 +6,7 @@ slightly different behavior from the standard one.
 
 Users using both ``symfit`` and ``sympy`` should be aware of this.
 """
-
+import pkg_resources
 from sympy import HadamardProduct, MatPow, Idx, Inverse
 from sympy.printing.codeprinter import CodePrinter
 
@@ -40,6 +40,15 @@ def _print_HadamardProduct(self, printer):
     return "%s*%s" % (printer.doprint(self.args[0]),
                       printer.doprint(self.args[1]))
 HadamardProduct._numpycode = _print_HadamardProduct
+
+if pkg_resources.parse_version(pkg_resources.get_distribution('sympy').version) \
+        > pkg_resources.parse_version('1.4'):
+    from sympy import HadamardPower
+
+    def _print_HadamardPower(self, printer):
+        return "%s**%s" % (printer.doprint(self.args[0]),
+                          printer.doprint(self.args[1]))
+    HadamardPower._numpycode = _print_HadamardPower
 
 def _print_Idx(self, printer):
     """

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -246,8 +246,8 @@ def test_initial_parameters():
     fit = Fit(ode_model, t=tdata, a=AA, c=AAB, d=BAAB)
     results = fit.execute()
     print(results)
-    assert results.value(a0) == 10
-    assert results.value(c0) == pytest.approx(0)
+    assert results.value(a0) == pytest.approx(10, abs=1e-8)
+    assert results.value(c0) == pytest.approx(0, abs=1e-8)
 
     assert ode_model.params == [a0, c0, k, l, m, p]
     assert ode_model.initial_params == [a0, c0]


### PR DESCRIPTION
* Added HadamardPower printing

* Import HadamardPower only for sympy.__version__ > (1,4)

* Fixed the HadamardPower printer.

Co-authored-by: Martin Roelfs <u0114255@kuleuven.be>